### PR TITLE
When there is a name clash, ensure the chosen steam id is deterministic

### DIFF
--- a/lib/steam_ids.rb
+++ b/lib/steam_ids.rb
@@ -14,11 +14,17 @@ class SteamIds
   def populate_all_games(output)
     output.each_value do |games_list|
       games_list.each do |game|
-        g = @steam_ids['applist']['apps'].filter { |a| a['name'].strip.downcase == game.name.strip.downcase }
-        game.steam_id = g.last['appid'] unless g.empty?
+        # Match game and if it matches more than once, take the highest value - should be latest entry
+        matches = match_game(game)
+        game.steam_id = matches.max_by { |g| g['appid'] }['appid'] unless matches.empty?
       end
     end
 
     output
+  end
+
+  # Match game name against Steam ID list
+  def match_game(game)
+    @steam_ids['applist']['apps'].filter { |a| a['name'].strip.downcase == game.name.strip.downcase }
   end
 end

--- a/output/humble-choice-2015.yml
+++ b/output/humble-choice-2015.yml
@@ -54,7 +54,7 @@
   name: Rust
   month: December
   year: 2015
-  steam_id: 252490
+  steam_id: 980030
 - !ruby/object:Game
   name: PAYDAY 2
   month: December

--- a/output/humble-choice-2016.yml
+++ b/output/humble-choice-2016.yml
@@ -154,7 +154,7 @@
   name: Crawl
   month: May
   year: 2016
-  steam_id: 293780
+  steam_id: 535120
 - !ruby/object:Game
   name: Galak-Z
   month: May


### PR DESCRIPTION
Previously was taking whichever came out last. Instead, take the higher value as this should be the later entry and will only change if the source data changes.