### PR TITLE
Add ignorelist to verbose output

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,12 +14,14 @@ task :generate do
   hc = HumbleChoiceGenerator.new
   hc.generate
 
-
-  puts hc.missing_steam_ids.to_yaml
-
-  # system "grep -B4 --color -e 'steam_id: $' output/humble-choice-20*"
-  # puts '--'
-  # system "for file in output/humble-choice-20* ; do echo \"$file: \"; grep -e 'steam_id: $' $file | wc -l ; done"
+  # Output list of games with missing Steam Ids, skipping the ignore list
+  missing = hc.missing_steam_ids
+  missing.keys.sort.each do |year|
+    unless missing[year].empty?
+      o = { year => missing[year] }.to_yaml
+      puts o
+    end
+  end
 end
 
 # Generate everything silently

--- a/Rakefile
+++ b/Rakefile
@@ -14,9 +14,12 @@ task :generate do
   hc = HumbleChoiceGenerator.new
   hc.generate
 
-  system "grep -B4 --color -e 'steam_id: $' output/humble-choice-20*"
-  puts '--'
-  system "for file in output/humble-choice-20* ; do echo \"$file: \"; grep -e 'steam_id: $' $file | wc -l ; done"
+
+  puts hc.missing_steam_ids.to_yaml
+
+  # system "grep -B4 --color -e 'steam_id: $' output/humble-choice-20*"
+  # puts '--'
+  # system "for file in output/humble-choice-20* ; do echo \"$file: \"; grep -e 'steam_id: $' $file | wc -l ; done"
 end
 
 # Generate everything silently

--- a/Rakefile
+++ b/Rakefile
@@ -15,6 +15,7 @@ task :generate do
   hc.generate
 
   # Output list of games with missing Steam Ids, skipping the ignore list
+  hc.read_ignore_list
   missing = hc.missing_steam_ids
   missing.keys.sort.each do |year|
     unless missing[year].empty?

--- a/ignore-list.txt
+++ b/ignore-list.txt
@@ -1,0 +1,10 @@
+# Known games which will not have a Steam ID
+
+# Games on a non-Steam platform
+Black Ops 4 Battle Edition
+Overwatch
+
+# Games withdrawn from sale on Steam
+Beyond Eyes
+NBA 2K17
+Rapture Rejects

--- a/lib/humble_choice_generator.rb
+++ b/lib/humble_choice_generator.rb
@@ -5,6 +5,7 @@ require_relative './steam_ids'
 class HumbleChoiceGenerator
   def initialize
     @game_list = []
+    @ignore_list = []
   end
 
   # Convenience method to fire everything
@@ -37,14 +38,21 @@ class HumbleChoiceGenerator
     end
   end
 
+  def read_ignore_list
+    f = File.open('ignore-list.txt', 'r')
+    f.each_line do |line|
+      @ignore_list << line.chomp unless line.chars.first == '#'
+    end
+  end
+
   def missing_steam_ids
     missing = {}
     @game_list.each_key do |year|
       missing[year] = []
 
       @game_list[year].each do |game|
-        # TODO: skip if on ignore list
-        missing[year] << game if game.steam_id.nil?
+        # Include if empty, and not on ignore list
+        missing[year] << game if game.steam_id.nil? && !(@ignore_list.include? game.name)
       end
     end
 

--- a/lib/humble_choice_generator.rb
+++ b/lib/humble_choice_generator.rb
@@ -43,6 +43,7 @@ class HumbleChoiceGenerator
       missing[year] = []
 
       @game_list[year].each do |game|
+        # TODO: skip if on ignore list
         missing[year] << game if game.steam_id.nil?
       end
     end

--- a/lib/humble_choice_generator.rb
+++ b/lib/humble_choice_generator.rb
@@ -36,4 +36,17 @@ class HumbleChoiceGenerator
       f.close
     end
   end
+
+  def missing_steam_ids
+    missing = {}
+    @game_list.each_key do |year|
+      missing[year] = []
+
+      @game_list[year].each do |game|
+        missing[year] << game if game.steam_id.nil?
+      end
+    end
+
+    missing
+  end
 end


### PR DESCRIPTION
Reduces noise by hiding games which will not get a Steam Id because they are on a different platform or have been withdrawn from sale.

Also removes some Bash for a more pure-Ruby implementation.